### PR TITLE
feat: Add test coverage for CGLE and NS models

### DIFF
--- a/models/CGLE.py
+++ b/models/CGLE.py
@@ -16,6 +16,7 @@ from ml_collections import ConfigDict
 class CGLE_SETD_KT_CM_JAX(BaseModel):
     def __init__(self, params):
         self.params = params
+        self.timestep_validatate()
         self.derived_params = derived_params(params)
         self.params.L = self.derived_params["L"]
         self.params.Nt = self.derived_params["Nt"]
@@ -87,19 +88,19 @@ class CGLE_SETD_KT_CM_JAX(BaseModel):
             key, key1, key2 = jax.random.split(key, 3)
             noise_advective, noise_forcing = self.draw_noise(n_steps, key1, key2)
         else:
-            noise_advective, noise_forcing = noise, noise# this assumes only one is selected.
+            noise_advective, noise_forcing = noise[0], noise[1]
 
         self.validate_params()
         self.timestep_validatate()    
         ###SETDRK###
         if self.params.method == 'Dealiased_SETDRK4_forced':
-            def scan_fn(y, i):
-                y_next = self.step_Dealiased_SETDRK4_forced(y, noise_advective[i], noise_forcing[i])
+            def scan_fn(y, noise):
+                y_next = self.step_Dealiased_SETDRK4_forced(y, noise[0], noise[1])
                 return y_next, y_next
         else:
             raise ValueError(f"Method {self.params.method} not recognised")
         
-        u_out = jax.lax.scan(scan_fn, initial_state, jnp.arange(n_steps))
+        u_out = jax.lax.scan(scan_fn, initial_state, (noise_advective, noise_forcing))
 
         return u_out
     
@@ -126,7 +127,7 @@ def initial_condition(xx,yy,E,name):
     if name == 'random':
         import numpy as np
         N = xx.shape[0]
-        ans = 0.1 * (np.random.randn(N, N) + 1j * jnp.random.randn(N, N))
+        ans = 0.1 * (np.random.randn(N, N) + 1j * np.random.randn(N, N))
     elif name == 'zero':
         ans = jnp.zeros_like(xx) + 1j * jnp.zeros_like(yy)
     elif name == 'chebfun':
@@ -184,8 +185,8 @@ def SETDRK4(u, E, E_2, Q, f1, f2, f3, beta, basis, dt, dW, dB):
         """ Nonlinear part: N(psi) = - (1 + i*beta) * |psi|^2 * psi + noise """
         psi =  jnp.fft.ifftn(in_field)# real space (complex)
         b = - (1 + 1j * beta) * jnp.abs(psi)**2 * (psi) 
-        b = b + jnp.einsum('...ijk,...i->...jk', basis, dW )*1
-        b = b + jnp.einsum('...ijk,...i->...jk', basis, dB )*1
+        b = b + jnp.einsum('...ijk,...i->...jk', basis, dW)
+        b = b + jnp.einsum('...ijk,...i->...jk', basis, dB)
         return jnp.fft.fftn( b ) # back to fourier space (complex)
     v = jnp.fft.fftn(u)
     Nv = N(v,beta,basis,dt,dW,dB) #  N takes fourier -> physical space -> nonlinarity -> fourier

--- a/models/NS.py
+++ b/models/NS.py
@@ -15,6 +15,7 @@ class NS_SETD_KT_CM_JAX(BaseModel):
     # handle case by case considerations. 
     def __init__(self, params):
         self.params = params
+        self.timestep_validatate()
         self.derived_params = derived_params(params)
         self.params.L = self.derived_params["L"]
         self.params.Nt = self.derived_params["Nt"]
@@ -89,19 +90,19 @@ class NS_SETD_KT_CM_JAX(BaseModel):
             key, key1, key2, key3 = jax.random.split(key, 4)
             noise_salt, noise_sflt, noise_forcing = self.draw_noise(n_steps, key1, key2, key3)
         else:
-            noise_salt, noise_sflt, noise_forcing = noise, noise, noise# this assumes only one is selected.
+            noise_salt, noise_sflt, noise_forcing = noise[0], noise[1], noise[2]
 
         self.validate_params()
         self.timestep_validatate()    
 
         if self.params.method == 'Dealiased_SETDRK4':
-            def scan_fn(y, i):
-                y_next = self.step_Dealiased_SETDRK4(y, noise_salt[i], noise_sflt[i],noise_forcing[i])
+            def scan_fn(y, noise):
+                y_next = self.step_Dealiased_SETDRK4(y, noise[0], noise[1], noise[2])
                 return y_next, y_next
         else:
             raise ValueError(f"Method {self.params.method} not recognised")
         
-        u_out = jax.lax.scan(scan_fn, initial_state, jnp.arange(n_steps))
+        u_out = jax.lax.scan(scan_fn, initial_state, (noise_salt, noise_sflt, noise_forcing))
 
         return u_out
     

--- a/tests/tests_models_CGLE.py
+++ b/tests/tests_models_CGLE.py
@@ -1,0 +1,103 @@
+import os
+os.environ["JAX_ENABLE_X64"] = "true"
+import sys
+import pytest
+from jax import random
+import jax.numpy as jnp
+from ml_collections import ConfigDict
+
+# Add the models directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../models')))
+
+from CGLE import CGLE_SETD_KT_CM_JAX, initial_condition, stochastic_basis_specifier, derived_params
+
+# Define a fixture for the default parameters
+@pytest.fixture
+def default_params():
+    return ConfigDict({
+        "nx": 128,
+        "xmin": -50.0,
+        "xmax": 50.0,
+        "dt": 0.1,
+        "tmax": 1.0,
+        "alpha": 0.0,
+        "beta": 1.0,
+        "S": 9,
+        "E": 2,
+        "nt": 10,
+        "noise_magnitude": 0.001,
+        "Forcing_basis_name": 'sin_sin',
+        "initial_condition": 'chebfun',
+        "method": 'Dealiased_SETDRK4_forced',
+    })
+
+# Test the CGLE_SETD_KT_CM_JAX class
+def test_cgle_model_initialization(default_params):
+    model = CGLE_SETD_KT_CM_JAX(default_params)
+    assert model.params.nx == 128
+    assert model.params.E == 2
+    assert model.x.shape == (128,)
+    assert model.ksq.shape == (128, 128)
+    assert model.psi0.shape == (2, 128, 128)
+
+def test_cgle_model_validate_params(default_params):
+    with pytest.raises(ValueError, match="Number of ensemble members E must be greater than or equal to 1"):
+        default_params.E = 0
+        model = CGLE_SETD_KT_CM_JAX(default_params)
+        model.validate_params()
+
+def test_cgle_model_timestep_validate(default_params):
+    with pytest.raises(ValueError, match="Time step dt must be positive"):
+        default_params.dt = 0
+        model = CGLE_SETD_KT_CM_JAX(default_params)
+        model.timestep_validatate()
+    with pytest.raises(ValueError, match="does not match tmax"):
+        default_params.dt = 0.1
+        default_params.nt = 5
+        model = CGLE_SETD_KT_CM_JAX(default_params)
+        model.timestep_validatate()
+
+def test_cgle_model_run(default_params):
+    model = CGLE_SETD_KT_CM_JAX(default_params)
+    key = random.PRNGKey(0)
+    n_steps = default_params.nt
+    noise = (
+        random.normal(key, shape=(n_steps, default_params.E, default_params.S)),
+        random.normal(key, shape=(n_steps, default_params.E, default_params.S))
+    )
+    output = model.run(model.psi0, n_steps, noise, key)
+    assert output[1].shape == (n_steps, default_params.E, default_params.nx, default_params.nx)
+
+# Test the initial_condition function
+@pytest.mark.parametrize("name", ['random', 'zero', 'chebfun'])
+def test_initial_condition(name):
+    xx, yy = jnp.meshgrid(jnp.linspace(-1, 1, 10), jnp.linspace(-1, 1, 10))
+    E = 2
+    ic = initial_condition(xx, yy, E, name)
+    assert ic.shape == (E, 10, 10)
+
+def test_initial_condition_invalid():
+    xx, yy = jnp.meshgrid(jnp.linspace(-1, 1, 10), jnp.linspace(-1, 1, 10))
+    with pytest.raises(ValueError, match="not recognised"):
+        initial_condition(xx, yy, 1, 'invalid_name')
+
+# Test the stochastic_basis_specifier function
+@pytest.mark.parametrize("name", ['sin', 'sin_sin', 'x_sin', 'y_sin'])
+def test_stochastic_basis_specifier(name):
+    x, y = jnp.meshgrid(jnp.linspace(-1, 1, 10), jnp.linspace(-1, 1, 10))
+    P = 4
+    basis = stochastic_basis_specifier(x, y, P, name)
+    assert basis.shape == (P, 10, 10)
+
+def test_stochastic_basis_specifier_invalid():
+    x, y = jnp.meshgrid(jnp.linspace(-1, 1, 10), jnp.linspace(-1, 1, 10))
+    with pytest.raises(ValueError, match="not recognised"):
+        stochastic_basis_specifier(x, y, 1, 'invalid_name')
+
+# Test the derived_params function
+def test_derived_params():
+    params = {"xmax": 50.0, "xmin": -50.0, "tmax": 10.0, "dt": 0.1, "nx": 128}
+    d_params = derived_params(params)
+    assert d_params["L"] == 100.0
+    assert d_params["Nt"] == 100
+    assert d_params["dx"] == 100.0 / 128

--- a/tests/tests_models_NS.py
+++ b/tests/tests_models_NS.py
@@ -1,0 +1,110 @@
+import os
+os.environ["JAX_ENABLE_X64"] = "true"
+import sys
+import pytest
+from jax import random
+import jax.numpy as jnp
+from ml_collections import ConfigDict
+
+# Add the models directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../models')))
+
+from NS import NS_SETD_KT_CM_JAX, initial_condition, stochastic_basis_specifier, derived_params
+
+# Define a fixture for the default parameters
+@pytest.fixture
+def default_params():
+    return ConfigDict({
+        "nx": 64,
+        "xmin": 0.0,
+        "xmax": 1.0,
+        "dt": 0.01,
+        "tmax": 0.1,
+        "mu": 0.001,
+        "nu": 0.0001,
+        "S_1": 4,
+        "S_2": 4,
+        "S_3": 4,
+        "E": 2,
+        "nt": 10,
+        "noise_magnitude_1": 0.001,
+        "noise_magnitude_2": 0.001,
+        "noise_magnitude_3": 0.001,
+        "SALT_basis_name": 'sin_sin',
+        "SFLT_basis_name": 'sin_sin',
+        "Forcing_basis_name": 'sin_sin',
+        "initial_condition": 'smoz',
+        "method": 'Dealiased_SETDRK4',
+    })
+
+# Test the NS_SETD_KT_CM_JAX class
+def test_ns_model_initialization(default_params):
+    model = NS_SETD_KT_CM_JAX(default_params)
+    assert model.params.nx == 64
+    assert model.params.E == 2
+    assert model.x.shape == (64,)
+    assert model.ksq.shape == (64, 64)
+    assert model.psi0.shape == (2, 64, 64)
+
+def test_ns_model_validate_params(default_params):
+    with pytest.raises(ValueError, match="Number of ensemble members E must be greater than or equal to 1"):
+        default_params.E = 0
+        model = NS_SETD_KT_CM_JAX(default_params)
+        model.validate_params()
+
+def test_ns_model_timestep_validate(default_params):
+    with pytest.raises(ValueError, match="Time step dt must be positive"):
+        default_params.dt = 0
+        model = NS_SETD_KT_CM_JAX(default_params)
+        model.timestep_validatate()
+    with pytest.raises(ValueError, match="does not match tmax"):
+        default_params.dt = 0.01
+        default_params.nt = 5
+        model = NS_SETD_KT_CM_JAX(default_params)
+        model.timestep_validatate()
+
+def test_ns_model_run(default_params):
+    model = NS_SETD_KT_CM_JAX(default_params)
+    key = random.PRNGKey(0)
+    n_steps = default_params.nt
+    noise = (
+        random.normal(key, shape=(n_steps, default_params.E, default_params.S_1)),
+        random.normal(key, shape=(n_steps, default_params.E, default_params.S_2)),
+        random.normal(key, shape=(n_steps, default_params.E, default_params.S_3))
+    )
+    output = model.run(model.psi0, n_steps, noise, key)
+    assert output[1].shape == (n_steps, default_params.E, default_params.nx, default_params.nx)
+
+# Test the initial_condition function
+@pytest.mark.parametrize("name", ['random', 'smoz', 'sinsin'])
+def test_initial_condition(name):
+    xx, yy = jnp.meshgrid(jnp.linspace(0, 1, 10), jnp.linspace(0, 1, 10))
+    E = 2
+    ic = initial_condition(xx, yy, E, name)
+    assert ic.shape == (E, 10, 10)
+
+def test_initial_condition_invalid():
+    xx, yy = jnp.meshgrid(jnp.linspace(0, 1, 10), jnp.linspace(0, 1, 10))
+    with pytest.raises(ValueError, match="not recognised"):
+        initial_condition(xx, yy, 1, 'invalid_name')
+
+# Test the stochastic_basis_specifier function
+@pytest.mark.parametrize("name", ['sin', 'sin_sin', 'x_sin', 'y_sin'])
+def test_stochastic_basis_specifier(name):
+    x, y = jnp.meshgrid(jnp.linspace(0, 1, 10), jnp.linspace(0, 1, 10))
+    P = 4
+    basis = stochastic_basis_specifier(x, y, P, name)
+    assert basis.shape == (P, 10, 10)
+
+def test_stochastic_basis_specifier_invalid():
+    x, y = jnp.meshgrid(jnp.linspace(0, 1, 10), jnp.linspace(0, 1, 10))
+    with pytest.raises(ValueError, match="not recognised"):
+        stochastic_basis_specifier(x, y, 1, 'invalid_name')
+
+# Test the derived_params function
+def test_derived_params():
+    params = {"xmax": 1.0, "xmin": 0.0, "tmax": 10.0, "dt": 0.1, "nx": 128}
+    d_params = derived_params(params)
+    assert d_params["L"] == 1.0
+    assert d_params["Nt"] == 100
+    assert d_params["dx"] == 1.0 / 128


### PR DESCRIPTION
This commit introduces comprehensive test suites for the `CGLE` and `NS` models, which were previously untested.

The new tests cover:
- Model initialization
- Parameter validation
- Timestepping logic
- Helper functions for initial conditions and stochastic basis

In the process of adding these tests, several bugs were identified and fixed in the model implementations, including:
- A `ZeroDivisionError` during initialization with a zero timestep.
- A `TracerIntegerConversionError` in the JAX scan function due to incorrect indexing.
- An `AttributeError` from an incorrect `jnp.random` call.

These changes significantly improve the robustness and reliability of the simulation models.